### PR TITLE
Update verify-signup-set-password.js

### DIFF
--- a/src/verify-signup-set-password.js
+++ b/src/verify-signup-set-password.js
@@ -69,8 +69,7 @@ async function verifySignupSetPassword (options, query, tokens, password, field,
   ]);
 
   if (!Object.keys(tokens).every((key) => tokens[key] === user1[key])) {
-    // Commented to fix a security issue where password is set even if token don't match.
-    // await eraseVerifyPropsSetPassword(user1, user1.isVerified, {}, password, field);
+    await eraseVerifyProps(user1, user1.isVerified, {});
 
     throw new errors.BadRequest(
       'Invalid token. Get for a new one. (authLocalMgnt)',
@@ -89,6 +88,19 @@ async function verifySignupSetPassword (options, query, tokens, password, field,
   const user3 = await notifier(options.notifier, 'verifySignupSetPassword', user2, notifierOptions);
   return options.sanitizeUserForClient(user3);
 
+  async function eraseVerifyProps (user, isVerified, verifyChanges) {
+    const patchToUser = Object.assign({}, verifyChanges || {}, {
+      isVerified,
+      verifyToken: null,
+      verifyShortToken: null,
+      verifyExpires: null,
+      verifyChanges: {}
+    });
+
+    const result = await usersService.patch(user[usersServiceIdName], patchToUser, {});
+    return result;
+  }
+  
   async function eraseVerifyPropsSetPassword (user, isVerified, verifyChanges, password, field) {
     const hashedPassword = await hashPassword(options.app, password, field);
 

--- a/src/verify-signup-set-password.js
+++ b/src/verify-signup-set-password.js
@@ -69,7 +69,8 @@ async function verifySignupSetPassword (options, query, tokens, password, field,
   ]);
 
   if (!Object.keys(tokens).every((key) => tokens[key] === user1[key])) {
-    await eraseVerifyPropsSetPassword(user1, user1.isVerified, {}, password, field);
+    // Commented to fix a security issue where password is set even if token don't match.
+    // await eraseVerifyPropsSetPassword(user1, user1.isVerified, {}, password, field);
 
     throw new errors.BadRequest(
       'Invalid token. Get for a new one. (authLocalMgnt)',


### PR DESCRIPTION
Commented this line to fix a security issue where password is set even if token don't match.

`await eraseVerifyPropsSetPassword(user1, user1.isVerified, {}, password, field);`


Related to : https://github.com/feathersjs-ecosystem/feathers-authentication-management/pull/142#issuecomment-867766756