### PR TITLE
Pass Params to all service calls.

### DIFF
--- a/src/check-unique.js
+++ b/src/check-unique.js
@@ -8,7 +8,7 @@ const debug = makeDebug('authLocalMgnt:checkUnique');
 module.exports = checkUnique;
 
 // This module is usually called from the UI to check username, email, etc. are unique.
-async function checkUnique (options, identifyUser, ownId, meta) {
+async function checkUnique (options, identifyUser, ownId, meta, params = {}) {
   debug('checkUnique', identifyUser, ownId, meta);
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
@@ -21,7 +21,7 @@ async function checkUnique (options, identifyUser, ownId, meta) {
   try {
     for (let i = 0, ilen = keys.length; i < ilen; i++) {
       const prop = keys[i];
-      const users = await usersService.find({ query: { [prop]: identifyUser[prop].trim() } });
+      const users = await usersService.find({ ...params, query: { [prop]: identifyUser[prop].trim() } });
       const items = Array.isArray(users) ? users : users.data;
       const isNotUnique = items.length > 1 ||
         (items.length === 1 && items[0][usersServiceIdName] !== ownId);

--- a/src/identity-change.js
+++ b/src/identity-change.js
@@ -12,7 +12,7 @@ const debug = makeDebug('authLocalMgnt:identityChange');
 
 module.exports = identityChange;
 
-async function identityChange (options, identifyUser, password, changesIdentifyUser, notifierOptions = {}) {
+async function identityChange (options, identifyUser, password, changesIdentifyUser, notifierOptions = {}, params = {}) {
   // note this call does not update the authenticated user info in hooks.params.user.
   debug('identityChange', password, changesIdentifyUser);
   const usersService = options.app.service(options.service);
@@ -21,7 +21,7 @@ async function identityChange (options, identifyUser, password, changesIdentifyU
   ensureObjPropsValid(identifyUser, options.identifyUserProps);
   ensureObjPropsValid(changesIdentifyUser, options.identifyUserProps);
 
-  const users = await usersService.find({ query: identifyUser });
+  const users = await usersService.find({ ...params, query: identifyUser });
   const user1 = getUserData(users);
 
   try {
@@ -37,7 +37,7 @@ async function identityChange (options, identifyUser, password, changesIdentifyU
     verifyToken: await getLongToken(options.longTokenLen),
     verifyShortToken: await getShortToken(options.shortTokenLen, options.shortTokenDigits),
     verifyChanges: changesIdentifyUser
-  });
+  }, params);
 
   const user3 = await notifier(options.notifier, 'identityChange', user2, notifierOptions);
   return options.sanitizeUserForClient(user3);

--- a/src/password-change.js
+++ b/src/password-change.js
@@ -12,7 +12,7 @@ const debug = makeDebug('authLocalMgnt:passwordChange');
 
 module.exports = passwordChange;
 
-async function passwordChange (options, identifyUser, oldPassword, password, field, notifierOptions = {}) {
+async function passwordChange (options, identifyUser, oldPassword, password, field, notifierOptions = {}, params = {}) {
   debug('passwordChange', oldPassword, password);
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
@@ -20,7 +20,7 @@ async function passwordChange (options, identifyUser, oldPassword, password, fie
   ensureValuesAreStrings(oldPassword, password);
   ensureObjPropsValid(identifyUser, options.identifyUserProps);
 
-  const users = await usersService.find({ query: identifyUser });
+  const users = await usersService.find({ ...params, query: identifyUser });
   const user1 = getUserData(users);
 
   try {
@@ -33,7 +33,7 @@ async function passwordChange (options, identifyUser, oldPassword, password, fie
 
   const user2 = await usersService.patch(user1[usersServiceIdName], {
     password: await hashPassword(options.app, password, field)
-  });
+  }, params);
 
   const user3 = await notifier(options.notifier, 'passwordChange', user2, notifierOptions);
   return options.sanitizeUserForClient(user3);

--- a/src/resend-verify-signup.js
+++ b/src/resend-verify-signup.js
@@ -10,7 +10,7 @@ const debug = makeDebug('authLocalMgnt:resendVerifySignup');
 
 // {email}, {cellphone}, {verifyToken}, {verifyShortToken},
 // {email, cellphone, verifyToken, verifyShortToken}
-module.exports = async function resendVerifySignup (options, identifyUser, notifierOptions) {
+module.exports = async function resendVerifySignup (options, identifyUser, notifierOptions = {}, params = {}) {
   debug('identifyUser=', identifyUser);
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
@@ -19,7 +19,7 @@ module.exports = async function resendVerifySignup (options, identifyUser, notif
     options.identifyUserProps.concat('verifyToken', 'verifyShortToken')
   );
 
-  const users = await usersService.find({ query: identifyUser });
+  const users = await usersService.find({ ...params, query: identifyUser });
   const user1 = getUserData(users, ['isNotVerified']);
 
   const user2 = await usersService.patch(user1[usersServiceIdName], {
@@ -27,7 +27,7 @@ module.exports = async function resendVerifySignup (options, identifyUser, notif
     verifyExpires: Date.now() + options.delay,
     verifyToken: await getLongToken(options.longTokenLen),
     verifyShortToken: await getShortToken(options.shortTokenLen, options.shortTokenDigits)
-  });
+  }, params);
 
   const user3 = await notifier(options.notifier, 'resendVerifySignup', user2, notifierOptions);
   return options.sanitizeUserForClient(user3);

--- a/src/reset-password.js
+++ b/src/reset-password.js
@@ -15,20 +15,20 @@ module.exports = {
   resetPwdWithShortToken
 };
 
-async function resetPwdWithLongToken (options, resetToken, password, field, notifierOptions = {}) {
+async function resetPwdWithLongToken (options, resetToken, password, field, notifierOptions = {}, params = {}) {
   ensureValuesAreStrings(resetToken, password);
 
-  return resetPassword(options, { resetToken }, { resetToken }, password, field, notifierOptions);
+  return resetPassword(options, { resetToken }, { resetToken }, password, field, notifierOptions, params);
 }
 
-async function resetPwdWithShortToken (options, resetShortToken, identifyUser, password, field, notifierOptions = {}) {
+async function resetPwdWithShortToken (options, resetShortToken, identifyUser, password, field, notifierOptions = {}, params = {}) {
   ensureValuesAreStrings(resetShortToken, password);
   ensureObjPropsValid(identifyUser, options.identifyUserProps);
 
-  return resetPassword(options, identifyUser, { resetShortToken }, password, field, notifierOptions);
+  return resetPassword(options, identifyUser, { resetShortToken }, password, field, notifierOptions, params);
 }
 
-async function resetPassword (options, query, tokens, password, field, notifierOptions = {}) {
+async function resetPassword (options, query, tokens, password, field, notifierOptions = {}, params = {}) {
   debug('resetPassword', query, tokens, password);
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
@@ -36,9 +36,9 @@ async function resetPassword (options, query, tokens, password, field, notifierO
 
   if (tokens.resetToken) {
     let id = deconstructId(tokens.resetToken);
-    users = await usersService.get(id);
+    users = await usersService.get(id, params);
   } else if (tokens.resetShortToken) {
-    users = await usersService.find({ query });
+    users = await usersService.find({ ...params, query });
   } else {
     throw new errors.BadRequest('resetToken and resetShortToken are missing. (authLocalMgnt)', {
       errors: { $className: 'missingToken' }
@@ -74,7 +74,7 @@ async function resetPassword (options, query, tokens, password, field, notifierO
     if (user1.resetAttempts > 0) {
       await usersService.patch(user1[usersServiceIdName], {
         resetAttempts: user1.resetAttempts - 1
-      });
+      }, params);
 
       throw err;
     } else {
@@ -83,7 +83,7 @@ async function resetPassword (options, query, tokens, password, field, notifierO
         resetAttempts: null,
         resetShortToken: null,
         resetExpires: null
-      });
+      }, params);
 
       throw new errors.BadRequest('Invalid token. Get for a new one. (authLocalMgnt)', {
         errors: { $className: 'invalidToken' }
@@ -97,7 +97,7 @@ async function resetPassword (options, query, tokens, password, field, notifierO
     resetAttempts: null,
     resetToken: null,
     resetShortToken: null
-  });
+  }, params);
 
   const user3 = await notifier(options.notifier, 'resetPwd', user2, notifierOptions);
   return options.sanitizeUserForClient(user3);

--- a/src/send-reset-pwd.js
+++ b/src/send-reset-pwd.js
@@ -11,14 +11,14 @@ const debug = makeDebug('authLocalMgnt:sendResetPwd');
 
 module.exports = sendResetPwd;
 
-async function sendResetPwd (options, identifyUser, field, notifierOptions = {}) {
+async function sendResetPwd (options, identifyUser, field, notifierOptions = {}, params = {}) {
   debug('sendResetPwd');
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
 
   ensureObjPropsValid(identifyUser, options.identifyUserProps);
 
-  const users = await usersService.find({ query: identifyUser });
+  const users = await usersService.find({ ...params, query: identifyUser });
   const user1 = getUserData(users, options.skipIsVerifiedCheck ? [] : ['isVerified']);
 
   if (
@@ -50,7 +50,7 @@ async function sendResetPwd (options, identifyUser, field, notifierOptions = {})
       options.reuseResetToken
         ? user2.resetShortToken
         : await hashPassword(options.app, user2.resetShortToken, field)
-  });
+  }, params);
 
   return options.sanitizeUserForClient(user3);
 }

--- a/src/service.js
+++ b/src/service.js
@@ -37,10 +37,7 @@ const optionsDefault = {
   reuseResetToken: false,
   identifyUserProps: ['email'],
   sanitizeUserForClient,
-  passParams: async (params) => {
-    let {provider: _, query: __, ...passedParams} = params;
-    return passedParams;
-  }
+  passParams: undefined,
 };
 
 module.exports = authenticationLocalManagement;
@@ -59,7 +56,7 @@ function authLocalMgntMethods (options) {
     async create (data, params) {
       debug(`create called. action=${data.action}`);
 
-      let passedParams = await options.passParams(params);
+      let passedParams = options.passParams && await options.passParams(params);
 
       switch (data.action) {
         case 'checkUnique':

--- a/src/service.js
+++ b/src/service.js
@@ -36,7 +36,11 @@ const optionsDefault = {
   resetAttempts: 0,
   reuseResetToken: false,
   identifyUserProps: ['email'],
-  sanitizeUserForClient
+  sanitizeUserForClient,
+  passParams: async (params) => {
+    let {provider: _, query: __, ...passedParams} = params;
+    return passedParams;
+  }
 };
 
 module.exports = authenticationLocalManagement;
@@ -55,7 +59,7 @@ function authLocalMgntMethods (options) {
     async create (data, params) {
       debug(`create called. action=${data.action}`);
 
-      let {provider: _, query: __, ...passedParams} = params;
+      let passedParams = await options.passParams(params);
 
       switch (data.action) {
         case 'checkUnique':

--- a/src/service.js
+++ b/src/service.js
@@ -52,8 +52,10 @@ function authenticationLocalManagement (options1 = {}, docs = {}) {
 
 function authLocalMgntMethods (options) {
   return {
-    async create (data) {
+    async create (data, params) {
       debug(`create called. action=${data.action}`);
+
+      let {provider: _, query: __, ...passedParams} = params;
 
       switch (data.action) {
         case 'checkUnique':
@@ -62,7 +64,8 @@ function authLocalMgntMethods (options) {
               options,
               data.value,
               data.ownId || null,
-              data.meta || {}
+              data.meta || {},
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err); // support both async and Promise interfaces
@@ -72,7 +75,8 @@ function authLocalMgntMethods (options) {
             return await resendVerifySignup(
               options,
               data.value,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -82,7 +86,8 @@ function authLocalMgntMethods (options) {
             return await verifySignupWithLongToken(
               options,
               data.value,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -93,7 +98,8 @@ function authLocalMgntMethods (options) {
               options,
               data.value.token,
               data.value.user,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -105,7 +111,8 @@ function authLocalMgntMethods (options) {
               data.value.token,
               data.value.password,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -118,7 +125,8 @@ function authLocalMgntMethods (options) {
               data.value.user,
               data.value.password,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -129,7 +137,8 @@ function authLocalMgntMethods (options) {
               options,
               data.value,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -141,7 +150,8 @@ function authLocalMgntMethods (options) {
               data.value.token,
               data.value.password,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -154,7 +164,8 @@ function authLocalMgntMethods (options) {
               data.value.user,
               data.value.password,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -167,7 +178,8 @@ function authLocalMgntMethods (options) {
               data.value.oldPassword,
               data.value.password,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);
@@ -180,7 +192,8 @@ function authLocalMgntMethods (options) {
               data.value.password,
               data.value.changes,
               passwordField,
-              data.notifierOptions
+              data.notifierOptions,
+              passedParams,
             );
           } catch (err) {
             return Promise.reject(err);

--- a/src/verify-signup.js
+++ b/src/verify-signup.js
@@ -13,27 +13,27 @@ module.exports = {
   verifySignupWithShortToken
 };
 
-async function verifySignupWithLongToken (options, verifyToken, notifierOptions = {}) {
+async function verifySignupWithLongToken (options, verifyToken, notifierOptions = {}, params = {}) {
   ensureValuesAreStrings(verifyToken);
 
-  const result = await verifySignup(options, { verifyToken }, { verifyToken }, notifierOptions);
+  const result = await verifySignup(options, { verifyToken }, { verifyToken }, notifierOptions, params);
   return result;
 }
 
-async function verifySignupWithShortToken (options, verifyShortToken, identifyUser, notifierOptions = {}) {
+async function verifySignupWithShortToken (options, verifyShortToken, identifyUser, notifierOptions = {}, params = {}) {
   ensureValuesAreStrings(verifyShortToken);
   ensureObjPropsValid(identifyUser, options.identifyUserProps);
 
-  const result = await verifySignup(options, identifyUser, { verifyShortToken }, notifierOptions);
+  const result = await verifySignup(options, identifyUser, { verifyShortToken }, notifierOptions, params);
   return result;
 }
 
-async function verifySignup (options, query, tokens, notifierOptions = {}) {
+async function verifySignup (options, query, tokens, notifierOptions = {}, params = {}) {
   debug('verifySignup', query, tokens);
   const usersService = options.app.service(options.service);
   const usersServiceIdName = usersService.id;
 
-  const users = await usersService.find({ query });
+  const users = await usersService.find({ ...params, query });
   const user1 = getUserData(users, ['isNotVerifiedOrHasVerifyChanges', 'verifyNotExpired']);
 
   if (!Object.keys(tokens).every(key => tokens[key] === user1[key])) {
@@ -57,7 +57,7 @@ async function verifySignup (options, query, tokens, notifierOptions = {}) {
       verifyChanges: {}
     });
 
-    const result = await usersService.patch(user[usersServiceIdName], patchToUser, {});
+    const result = await usersService.patch(user[usersServiceIdName], patchToUser, params);
     return result;
   }
 }

--- a/test/scaffolding.test.js
+++ b/test/scaffolding.test.js
@@ -17,20 +17,32 @@ const optionsDefault = {
   resetAttempts: 0,
   reuseResetToken: false,
   identifyUserProps: ['email'],
-  sanitizeUserForClient: helpers.sanitizeUserForClient
+  sanitizeUserForClient: helpers.sanitizeUserForClient,
+  passParams: async (params) => {
+    let {provider: _, query: __, ...passedParams} = params;
+    return passedParams;
+  }
 };
 
 const userMgntOptions = {
   service: '/users',
   notifier: () => Promise.resolve(),
-  shortTokenLen: 8
+  shortTokenLen: 8,
+  passParams: async (params) => {
+    let {provider: _, query: __, ...passedParams} = params;
+    return passedParams;
+  }
 };
 
 const orgMgntOptions = {
   service: '/organizations',
   path: 'authManagement/org', // *** specify path for this instance of service
   notifier: () => Promise.resolve(),
-  shortTokenLen: 10
+  shortTokenLen: 10,
+  passParams: async (params) => {
+    let {provider: _, query: __, ...passedParams} = params;
+    return passedParams;
+  }
 };
 
 function services () {


### PR DESCRIPTION
### Summary

I am wanting to pass all params except provider, and query to all service calls for auth management. This is so the internal call will get all params and custom params for server-side hooks. We need to pass additional params, but the current code is fixed.