### PR TITLE
FIX identityChange service all

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -192,7 +192,6 @@ function authLocalMgntMethods (options) {
               data.value.user,
               data.value.password,
               data.value.changes,
-              passwordField,
               data.notifierOptions,
               passedParams,
             );


### PR DESCRIPTION
The `passwordField` params is pass as 5th params to the `identityChange` method which DOES NOT expected this param. Instead it is overriding the `notifierOptions` params and makes it impossible to pass notifier option to the call.
