### PR TITLE
fix verifyChanges causing 0: {, 1: } during insert and patch

### DIFF
--- a/src/helpers/get-user-data.ts
+++ b/src/helpers/get-user-data.ts
@@ -97,6 +97,10 @@ export function getUserData (
 
   const user = checkOneUser(users);
 
+  if (typeof user.verifyChanges === "string" && user.verifyChanges[0] === "{") {
+    user.verifyChanges = JSON.parse(user.verifyChanges);
+  }
+
   checkUserChecks(user, checks);
 
   return user;


### PR DESCRIPTION
Due to fact that most realtional dbs do not support string[] inside single column, people cast verifyChanges to text type.
When field is deserialized from db we need to parse it twice. Otherwise Object.assign({}, '{}') will yield {0:'{', 1: '}'}

Related issue:
https://github.com/feathersjs-ecosystem/feathers-authentication-management/issues/206
